### PR TITLE
fix-wallet-creation

### DIFF
--- a/sources/init_copy_host_files.sh
+++ b/sources/init_copy_host_files.sh
@@ -39,10 +39,8 @@ else
 fi
 
 # Wallet to use
-if [ -z $WALLET_PRIVATE_KEY ]
+if [ -e $PATH_MOUNT/wallet_* ]
 then
-	warn "ERROR" "Secret key is not set, please set WALLET_PRIVATE_KEY in your docker-compose.yml. A new wallet will be created"
-else
-	green "INFO" "Loading wallet from private key"
-	massa-cli -j wallet_add_secret_keys $WALLET_PRIVATE_KEY
+	cp $PATH_MOUNT/wallet_* $PATH_CLIENT/wallets/
+	green "INFO" "Load wallet from massa_mount to client"
 fi

--- a/sources/lib.sh
+++ b/sources/lib.sh
@@ -37,15 +37,15 @@ CheckOrCreateWalletAndNodeKey() {
 
 	walletAddress=$(GetWalletAddress)
 
-	## Create a wallet, stacke and backup
+	## Import wallet, stake and backup
 	# If wallet don't exist
 	if [ -z "$walletAddress" ]
 	then
 		# Generate wallet
-		massa-cli wallet_generate_secret_key > /dev/null
+		massa-cli -j wallet_add_secret_keys $WALLET_PRIVATE_KEY > /dev/null
 		walletAddress=$(GetWalletAddress)
 		walletFile=wallet_$walletAddress.yaml
-		green "INFO" "Wallet $walletAddress created"
+		green "INFO" "Wallet $walletAddress imported"
 	fi
 
 	# Backup wallet to the mount point
@@ -53,7 +53,7 @@ CheckOrCreateWalletAndNodeKey() {
 	then
 		walletFile=wallet_$walletAddress.yaml
 		cp $PATH_CLIENT/wallets/$walletFile $PATH_MOUNT/$walletFile
-		green "INFO" "Backup $walletFile"
+		green "INFO" "Backup $walletFile to massa_mount"
 	fi
 
 	## Check if wallet is staked


### PR DESCRIPTION
Hey. Here some possible fixes for wallet creation.

Firstly, we can not import wallet in `init_copy_host_files.sh` because it is executed before bootstrap so massa-cli is unavailable to use. So I changed there to just copy wallet from mount to client id exist.

Secondly, I think we don't need to create dummy wallet like we do in testnet, instead of that I carried the import part to `lib.sh` to replace generate wallet. Please check @peterjah. Thank you for your work.